### PR TITLE
remove comments from JSON string

### DIFF
--- a/src/JsConverter.php
+++ b/src/JsConverter.php
@@ -23,7 +23,7 @@ class JsConverter
         $replacedStringsList = [];
 
         // 1. Remove functions from objects
-        $convertedString = self::removeFunctions($jsObjectString);
+        $convertedString = self::removeFunctions(self::removeComments($jsObjectString));
 
         // 2. Replace all delimited string literals with placeholders
         $convertedString = self::replaceSectionsWithPlaceholders($convertedString, $replacedStringsList, "'");
@@ -279,5 +279,16 @@ class JsConverter
             // Unescape contained single quotes
             $string = preg_replace("/\\\\'/", "'", $string);
         }
+    }
+
+    /**
+     * Removes oneline and multiline comments from JSON string
+     *
+     * @param string $jsonString
+     * @return string
+     */
+    protected static function removeComments(string $jsonString): string
+    {
+        return preg_replace("/\/\*[\s\S]*?\*\/|((?!>:)|^)\/\/.*$/m", "", $jsonString);
     }
 }

--- a/tests/JsConverterTest.php
+++ b/tests/JsConverterTest.php
@@ -275,4 +275,22 @@ EOT;
 
         $this->assertEquals($expected, $converted);
     }
+
+    public function testComments()
+    {
+        $input = <<<EOT
+{
+    // comment1
+    key1: null, // comment2
+    key2: true, /* comment3 */
+    /* comment4 */
+    key3: false
+}
+EOT;
+        $expected = '{"key1":null,"key2":true,"key3":false}';
+
+        $converted = JsConverter::convertToJson($input);
+
+        $this->assertEquals($expected, $converted);
+    }
 }


### PR DESCRIPTION
#11 

Recognizes:
- one-line comments like `// comment`
- open-close comments like `/* comment */` 
- multi-line comments like
```
  /*
  comment
  */
  ```
  