### PR TITLE
Remove "var/const/let myObject = " and ";" at end of object

### DIFF
--- a/src/JsConverter.php
+++ b/src/JsConverter.php
@@ -80,6 +80,22 @@ class JsConverter
             $deep = true;
         } while (!empty($replacedStringsList));
 
+        // Is the first character of the string not the beginning of the object?
+        if ($convertedString[0] !== '{') {
+            // Remove the variable name and creation and any other characters before the object.
+            $convertedString = explode('{', $convertedString);
+            array_shift($convertedString);
+            $convertedString = '{' . implode('{', $convertedString);
+        }
+
+        // Is the last character of the string not the end of the object?
+        if ($convertedString[-1] !== '}') {
+            // Remove the ";" and any other characters after the object.
+            $convertedString = explode('}', $convertedString);
+            array_pop($convertedString);
+            $convertedString = implode('}', $convertedString) . '}';
+        }
+        
         return preg_replace('/:(")(true|false|null)(")/', ':$2', $convertedString);
     }
 


### PR DESCRIPTION
Lets say this is your JS object...

```
const myObject = {
   "myPropertyA": "myValue",
   "myPropertyB": "myValue"
};
```

The JS object minified will be...

```
constmyObject={"myPropertyA":"myValue","myPropertyB":"myValue"};
```

When I use this package, it does not remove the "constmyObject=" or the ";" line break at the end of the object.

This improvement will parse the final output string to remove keywords such as `const`. `let`, and `var`, remove variable names and equal operators before the object brackets `{`. This improvement will remove any semicolons the come after the object. And this improvement will remove any characters that come before and after the object in the final parsed string.

This will solve this issue I made earlier this year.
https://github.com/ovidigital/js-object-to-json/issues/20